### PR TITLE
Reduce Kudu Examples to two partitions

### DIFF
--- a/examples/sqoop-parquet-hdfs-impala/tables.yml
+++ b/examples/sqoop-parquet-hdfs-impala/tables.yml
@@ -29,7 +29,7 @@ tables:
       hash_by: # List of columns to hash by
         - col1
         - nmpTpId
-      num_partitions: 8 # Number of Kudu partitions to create
+      num_partitions: 2 # Number of Kudu partitions to create
     check_column: "tsCol" # Incrementing timestamp of numeric column used when incrementally pulling data (sqoop --check-column)
     primary_keys: # List of primary keys
       - "col1"
@@ -72,7 +72,7 @@ tables:
       hash_by: # List of columns to hash by
         - col1
         - nmpTpId
-      num_partitions: 8 # Number of Kudu partitions to create
+      num_partitions: 2 # Number of Kudu partitions to create
     check_column: "tsCol" # Incrementing timestamp of numeric column used when incrementally pulling data (sqoop --check-column)
     primary_keys: # List of primary keys
       - "col1"

--- a/examples/sqoop-parquet-hdfs-kudu-impala/tables.yml
+++ b/examples/sqoop-parquet-hdfs-kudu-impala/tables.yml
@@ -75,7 +75,7 @@ tables:
     kudu:
       hash_by: # List of columns to hash by
         - col1
-      num_partitions: 8 # Number of Kudu partitions to create
+      num_partitions: 2 # Number of Kudu partitions to create
     check_column: "tsCol" # Incrementing timestamp of numeric column used when incrementally pulling data (sqoop --check-column)
     primary_keys: # List of primary keys
       - "col1"

--- a/integration-tests/sqoop-parquet-hdfs-impala/tables.yml
+++ b/integration-tests/sqoop-parquet-hdfs-impala/tables.yml
@@ -33,7 +33,7 @@ tables:
     kudu:
       hash_by: # List of columns to hash by
         - Id
-      num_partitions: 8 # Number of Kudu partitions to create
+      num_partitions: 2 # Number of Kudu partitions to create
     check_column: Id # Incrementing timestamp of numeric column used when incrementally pulling data (sqoop --check-column)
     primary_keys: # List of primary keys
       - Id
@@ -72,7 +72,7 @@ tables:
     kudu:
       hash_by: # List of columns to hash by
         - Id
-      num_partitions: 8 # Number of Kudu partitions to create
+      num_partitions: 2 # Number of Kudu partitions to create
     check_column: Id # Incrementing timestamp of numeric column used when incrementally pulling data (sqoop --check-column)
     primary_keys: # List of primary keys
       - Id
@@ -102,7 +102,7 @@ tables:
     kudu:
       hash_by: # List of columns to hash by
         - Id
-      num_partitions: 8 # Number of Kudu partitions to create
+      num_partitions: 2 # Number of Kudu partitions to create
     check_column: Id # Incrementing timestamp of numeric column used when incrementally pulling data (sqoop --check-column)
     primary_keys: # List of primary keys
       - Id

--- a/integration-tests/sqoop-parquet-hdfs-kudu-impala/tables.yml
+++ b/integration-tests/sqoop-parquet-hdfs-kudu-impala/tables.yml
@@ -33,7 +33,7 @@ tables:
     kudu:
       hash_by: # List of columns to hash by
         - Id
-      num_partitions: 8 # Number of Kudu partitions to create
+      num_partitions: 2 # Number of Kudu partitions to create
     check_column: Id # Incrementing timestamp of numeric column used when incrementally pulling data (sqoop --check-column)
     primary_keys: # List of primary keys
       - Id
@@ -76,7 +76,7 @@ tables:
     kudu:
       hash_by: # List of columns to hash by
         - Id
-      num_partitions: 8 # Number of Kudu partitions to create
+      num_partitions: 2 # Number of Kudu partitions to create
     check_column: Id # Incrementing timestamp of numeric column used when incrementally pulling data (sqoop --check-column)
     primary_keys: # List of primary keys
       - Id
@@ -110,7 +110,7 @@ tables:
     kudu:
       hash_by: # List of columns to hash by
         - Id
-      num_partitions: 8 # Number of Kudu partitions to create
+      num_partitions: 2 # Number of Kudu partitions to create
     check_column: Id # Incrementing timestamp of numeric column used when incrementally pulling data (sqoop --check-column)
     primary_keys: # List of primary keys
       - Id


### PR DESCRIPTION
In my expirence users tend to over partition tables. As such I think
we should lower the examples.