### PR TITLE
Adding support for kudu limitation: Columns that make up primary key should be listed first

### DIFF
--- a/pipewrench/merge.py
+++ b/pipewrench/merge.py
@@ -200,7 +200,7 @@ def render(template, **kwargs):
     :return: The reified template
     """
     template = Template(template)
-    template_functions = [map_datatypes, dumps, map_clobs]
+    template_functions = [map_datatypes, dumps, map_clobs, order_columns]
 
     for function in template_functions:
         template.globals[function.__name__] = function
@@ -326,3 +326,24 @@ def merge_single_template(template_file_path, type_mapping, conf):
     with codecs.open(template_file_path, 'r', 'UTF-8') as template_file:
         template = template_file.read()
         return render(template, conf=conf, table=table)
+
+def order_columns(pks,columns):
+    """
+    Orders column list to include primary keys first and then non primary
+    key columns
+    :param pks: primary key list
+    :param columns: columns
+    :return: primary key columns + non primary key columns (ordered) 
+    """
+    pk_list=[]
+    non_pk_list=[]
+
+    for c in columns:
+        for pk in pks:
+                if c.get("name")==pk:
+                        pk_list.append(c)
+                        break;
+                elif pks[-1]==pk:
+                        non_pk_list.append(c)
+
+    return pk_list+non_pk_list

--- a/pipewrench/merge.py
+++ b/pipewrench/merge.py
@@ -327,23 +327,23 @@ def merge_single_template(template_file_path, type_mapping, conf):
         template = template_file.read()
         return render(template, conf=conf, table=table)
 
-def order_columns(pks,columns):
+def order_columns(pks, columns):
     """
     Orders column list to include primary keys first and then non primary
     key columns
     :param pks: primary key list
     :param columns: columns
-    :return: primary key columns + non primary key columns (ordered) 
+    :return: primary key columns + non primary key columns ordered
     """
-    pk_list=[]
-    non_pk_list=[]
+    pk_list = []
+    non_pk_list = []
 
     for c in columns:
         for pk in pks:
-                if c.get("name")==pk:
-                        pk_list.append(c)
-                        break;
-                elif pks[-1]==pk:
-                        non_pk_list.append(c)
+            if c.get("name") == pk:
+                pk_list.append(c)
+                break
+            elif pks[-1] == pk:
+                non_pk_list.append(c)
 
     return pk_list+non_pk_list

--- a/templates/shared/kudu-table-create.sql
+++ b/templates/shared/kudu-table-create.sql
@@ -17,7 +17,7 @@ USE {{ conf.staging_database.name }};
 CREATE TABLE IF NOT EXISTS {{ table.destination.name }}_kudu
 {%- set ordered_columns = order_columns(table.primary_keys,table.columns) -%}
 ({%- for column in ordered_columns %}
-        {{ column.name }}
+        {{ column.name }} {{ map_datatypes(column).kudu }}
 {%- if not loop.last -%},{% endif %}
 {%- endfor %},
 primary key ({{ table.primary_keys|join(', ') }}))

--- a/templates/shared/kudu-table-create.sql
+++ b/templates/shared/kudu-table-create.sql
@@ -16,8 +16,8 @@
 USE {{ conf.staging_database.name }};
 CREATE TABLE IF NOT EXISTS {{ table.destination.name }}_kudu
 {%- set ordered_columns = order_columns(table.primary_keys,table.columns) -%}
-{%- for column in ordered_columns %}
-        {{ column.name }} {{ map_datatypes(column).kudu }}
+({%- for column in ordered_columns %}
+        {{ column.name }}
 {%- if not loop.last -%},{% endif %}
 {%- endfor %},
 primary key ({{ table.primary_keys|join(', ') }}))

--- a/templates/shared/kudu-table-create.sql
+++ b/templates/shared/kudu-table-create.sql
@@ -15,8 +15,9 @@
 -- Create a Kudu table in Impala
 USE {{ conf.staging_database.name }};
 CREATE TABLE IF NOT EXISTS {{ table.destination.name }}_kudu
-({%- for column in table.columns %}
-{{ column.name }} {{ map_datatypes(column).kudu }}
+{%- set ordered_columns = order_columns(table.primary_keys,table.columns) -%}
+{%- for column in ordered_columns %}
+        {{ column.name }} {{ map_datatypes(column).kudu }}
 {%- if not loop.last -%},{% endif %}
 {%- endfor %},
 primary key ({{ table.primary_keys|join(', ') }}))

--- a/templates/sqoop-parquet-hdfs-kudu-impala/kudu-table-insert.sql
+++ b/templates/sqoop-parquet-hdfs-kudu-impala/kudu-table-insert.sql
@@ -15,6 +15,10 @@
 USE {{ conf.staging_database.name }};
 REFRESH {{ table.destination.name }}_parquet;
 UPSERT INTO {{ table.destination.name }}_kudu SELECT
-    {{ table.columns|map(attribute='name')|join(',\n    ') }}
+{%- set ordered_columns = order_columns(table.primary_keys,table.columns) -%}
+{%- for column in ordered_columns %}
+        {{ column.name }}
+{%- if not loop.last -%},{% endif %}
+{%- endfor %}
         FROM {{ table.destination.name }}_parquet order by {{ table.check_column }}  asc
 


### PR DESCRIPTION
Columns that make up primary key should be listed first while creating a kudu table, to support this limitation :
1. Included template function order_columns(pks,columns) that orders the columns list to include primary keys first then non primary keys
2. Modified jinja templates :  kudu-table-create, kudu-table-insert to include the above function 