### PR TITLE
Added JDBCType data type mapping to all templates

### DIFF
--- a/templates/kudu-impala-hdfs-parquet-sqoop/type-mapping.yml
+++ b/templates/kudu-impala-hdfs-parquet-sqoop/type-mapping.yml
@@ -1,53 +1,29 @@
-date:
-  kudu: bigint
-  impala: bigint
-  parquet: bigint
-  avro: long
-timestamp:
-  kudu: bigint
-  impala: timestamp
-  parquet: bigint
-  avro: long
-datetime:
-  kudu: bigint
-  impala: timestamp
-  parquet: bigint
-  avro: long
+# numerics
 bigint:
   kudu: bigint
   impala: bigint
   parquet: bigint
   avro: long
+tinyint:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
 decimal:
   kudu: string
   impala: decimal
   parquet: double
   avro: decimal
-number:
-  kudu: string
-  impala: decimal
-  parquet: double
-  avro: decimal
-string:
-  kudu: string
-  impala: string
-  parquet: string
-  avro: string
 int:
   kudu: int
   impala: int
   parquet: int
   avro: int
-bit:
-  kudu: boolean
-  impala: boolean
-  parquet: boolean
-  avro: boolean
-boolean:
-  kudu: boolean
-  impala: boolean
-  parquet: boolean
-  avro: boolean
+number:
+  kudu: string
+  impala: decimal
+  parquet: double
+  avro: decimal
 numeric:
   kudu: string
   impala: string
@@ -68,6 +44,53 @@ float:
   impala: float
   parquet: float
   avro: float
+long:
+  kudu: bigint
+  parquet: bigint
+  impala: bigint
+  avro: long
+smallint:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
+integer:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
+# dates
+date:
+  kudu: bigint
+  impala: bigint
+  parquet: bigint
+  avro: long
+timestamp:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+datetime:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+time_with_timezone:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+timestamp_with_timezone:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+# text
+string:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
 blob:
   kudu: string
   impala: string
@@ -88,13 +111,59 @@ varchar:
   impala: string
   parquet: string
   avro: string
-long:
-  kudu: bigint
-  parquet: bigint
-  impala: bigint
-  avro: long
 text:
   kudu: string
   impala: string
   parquet: string
   avro: string
+char:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+binary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+varbinary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longvarbinary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+nchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+nvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longnvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+# boolean
+bit:
+  kudu: boolean
+  impala: boolean
+  parquet: boolean
+  avro: boolean
+boolean:
+  kudu: boolean
+  impala: boolean
+  parquet: boolean
+  avro: boolean

--- a/templates/kudu-table-ddl/type-mapping.yml
+++ b/templates/kudu-table-ddl/type-mapping.yml
@@ -1,53 +1,29 @@
-date:
-  kudu: bigint
-  impala: bigint
-  parquet: bigint
-  avro: long
-timestamp:
-  kudu: bigint
-  impala: timestamp
-  parquet: bigint
-  avro: long
-datetime:
-  kudu: bigint
-  impala: timestamp
-  parquet: bigint
-  avro: long
+# numerics
 bigint:
   kudu: bigint
   impala: bigint
   parquet: bigint
   avro: long
+tinyint:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
 decimal:
   kudu: string
   impala: decimal
   parquet: double
   avro: decimal
-number:
-  kudu: string
-  impala: decimal
-  parquet: double
-  avro: decimal
-string:
-  kudu: string
-  impala: string
-  parquet: string
-  avro: string
 int:
   kudu: int
   impala: int
   parquet: int
   avro: int
-bit:
-  kudu: boolean
-  impala: boolean
-  parquet: boolean
-  avro: boolean
-boolean:
-  kudu: boolean
-  impala: boolean
-  parquet: boolean
-  avro: boolean
+number:
+  kudu: string
+  impala: decimal
+  parquet: double
+  avro: decimal
 numeric:
   kudu: string
   impala: string
@@ -68,6 +44,53 @@ float:
   impala: float
   parquet: float
   avro: float
+long:
+  kudu: bigint
+  parquet: bigint
+  impala: bigint
+  avro: long
+smallint:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
+integer:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
+# dates
+date:
+  kudu: bigint
+  impala: bigint
+  parquet: bigint
+  avro: long
+timestamp:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+datetime:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+time_with_timezone:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+timestamp_with_timezone:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+# text
+string:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
 blob:
   kudu: string
   impala: string
@@ -88,13 +111,59 @@ varchar:
   impala: string
   parquet: string
   avro: string
-long:
-  kudu: bigint
-  parquet: bigint
-  impala: bigint
-  avro: long
 text:
   kudu: string
   impala: string
   parquet: string
   avro: string
+char:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+binary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+varbinary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longvarbinary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+nchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+nvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longnvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+# boolean
+bit:
+  kudu: boolean
+  impala: boolean
+  parquet: boolean
+  avro: boolean
+boolean:
+  kudu: boolean
+  impala: boolean
+  parquet: boolean
+  avro: boolean

--- a/templates/shared/type-mapping.yml
+++ b/templates/shared/type-mapping.yml
@@ -1,53 +1,29 @@
-date:
-  kudu: bigint
-  impala: bigint
-  parquet: bigint
-  avro: long
-timestamp:
-  kudu: bigint
-  impala: timestamp
-  parquet: bigint
-  avro: long
-datetime:
-  kudu: bigint
-  impala: timestamp
-  parquet: bigint
-  avro: long
+# numerics
 bigint:
   kudu: bigint
   impala: bigint
   parquet: bigint
   avro: long
+tinyint:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
 decimal:
   kudu: string
   impala: decimal
   parquet: double
   avro: decimal
-number:
-  kudu: string
-  impala: decimal
-  parquet: double
-  avro: decimal
-string:
-  kudu: string
-  impala: string
-  parquet: string
-  avro: string
 int:
   kudu: int
   impala: int
   parquet: int
   avro: int
-bit:
-  kudu: boolean
-  impala: boolean
-  parquet: boolean
-  avro: boolean
-boolean:
-  kudu: boolean
-  impala: boolean
-  parquet: boolean
-  avro: boolean
+number:
+  kudu: string
+  impala: decimal
+  parquet: double
+  avro: decimal
 numeric:
   kudu: string
   impala: string
@@ -68,6 +44,53 @@ float:
   impala: float
   parquet: float
   avro: float
+long:
+  kudu: bigint
+  parquet: bigint
+  impala: bigint
+  avro: long
+smallint:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
+integer:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
+# dates
+date:
+  kudu: bigint
+  impala: bigint
+  parquet: bigint
+  avro: long
+timestamp:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+datetime:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+time_with_timezone:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+timestamp_with_timezone:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+# text
+string:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
 blob:
   kudu: string
   impala: string
@@ -88,13 +111,59 @@ varchar:
   impala: string
   parquet: string
   avro: string
-long:
-  kudu: bigint
-  parquet: bigint
-  impala: bigint
-  avro: long
 text:
   kudu: string
   impala: string
   parquet: string
   avro: string
+char:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+binary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+varbinary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longvarbinary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+nchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+nvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longnvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+# boolean
+bit:
+  kudu: boolean
+  impala: boolean
+  parquet: boolean
+  avro: boolean
+boolean:
+  kudu: boolean
+  impala: boolean
+  parquet: boolean
+  avro: boolean

--- a/templates/sqoop-parquet-full-load/type-mapping.yml
+++ b/templates/sqoop-parquet-full-load/type-mapping.yml
@@ -1,53 +1,29 @@
-date:
-  kudu: bigint
-  impala: bigint
-  parquet: bigint
-  avro: bigint
-timestamp:
-  kudu: bigint
-  impala: timestamp
-  parquet: bigint
-  avro: bigint
-datetime:
-  kudu: bigint
-  impala: timestamp
-  parquet: bigint
-  avro: bigint
+# numerics
 bigint:
   kudu: bigint
   impala: bigint
   parquet: bigint
-  avro: bigint
+  avro: long
+tinyint:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
 decimal:
-  kudu: string
-  impala: decimal
-  parquet: decimal
-  avro: string
-number:
   kudu: string
   impala: decimal
   parquet: double
   avro: decimal
-string:
-  kudu: string
-  impala: string
-  parquet: string
-  avro: string
 int:
   kudu: int
   impala: int
   parquet: int
   avro: int
-bit:
-  kudu: boolean
-  impala: boolean
-  parquet: boolean
-  avro: boolean
-boolean:
-  kudu: boolean
-  impala: boolean
-  parquet: boolean
-  avro: boolean
+number:
+  kudu: string
+  impala: decimal
+  parquet: double
+  avro: decimal
 numeric:
   kudu: string
   impala: string
@@ -68,6 +44,53 @@ float:
   impala: float
   parquet: float
   avro: float
+long:
+  kudu: bigint
+  parquet: bigint
+  impala: bigint
+  avro: long
+smallint:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
+integer:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
+# dates
+date:
+  kudu: bigint
+  impala: bigint
+  parquet: bigint
+  avro: long
+timestamp:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+datetime:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+time_with_timezone:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+timestamp_with_timezone:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+# text
+string:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
 blob:
   kudu: string
   impala: string
@@ -88,53 +111,59 @@ varchar:
   impala: string
   parquet: string
   avro: string
-char:
-  kudu: string
-  impala: string
-  parquet: string
-  avro: string
-long:
-  kudu: bigint
-  parquet: bigint
-  impala: bigint
-  avro: bigint
 text:
   kudu: string
   impala: string
   parquet: string
   avro: string
-integer:
-  kudu: int
-  parquet: int
-  impala: int
-  avro: int
-nvarchar:
+char:
   kudu: string
-  parquet: string
   impala: string
+  parquet: string
   avro: string
-longnvarchar:
+longvarchar:
   kudu: string
-  parquet: string
   impala: string
-  avro: string
-longvarbinary:
-  kudu: string
   parquet: string
-  impala: string
-  avro: string
-varbinary:
-  kudu: string
-  parquet: string
-  impala: string
   avro: string
 binary:
   kudu: string
-  parquet: string
   impala: string
+  parquet: string
   avro: string
-smallint:
-  kudu: int
-  parquet: int
-  impala: int
-  avro: int
+varbinary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longvarbinary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+nchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+nvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longnvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+# boolean
+bit:
+  kudu: boolean
+  impala: boolean
+  parquet: boolean
+  avro: boolean
+boolean:
+  kudu: boolean
+  impala: boolean
+  parquet: boolean
+  avro: boolean

--- a/templates/sqoop-parquet-hdfs-impala/type-mapping.yml
+++ b/templates/sqoop-parquet-hdfs-impala/type-mapping.yml
@@ -1,53 +1,29 @@
-date:
-  kudu: bigint
-  impala: bigint
-  parquet: bigint
-  avro: long
-timestamp:
-  kudu: bigint
-  impala: timestamp
-  parquet: bigint
-  avro: long
-datetime:
-  kudu: bigint
-  impala: timestamp
-  parquet: bigint
-  avro: long
+# numerics
 bigint:
   kudu: bigint
   impala: bigint
   parquet: bigint
   avro: long
+tinyint:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
 decimal:
   kudu: string
   impala: decimal
   parquet: double
   avro: decimal
-number:
-  kudu: string
-  impala: decimal
-  parquet: double
-  avro: decimal
-string:
-  kudu: string
-  impala: string
-  parquet: string
-  avro: string
 int:
   kudu: int
   impala: int
   parquet: int
   avro: int
-bit:
-  kudu: boolean
-  impala: boolean
-  parquet: boolean
-  avro: boolean
-boolean:
-  kudu: boolean
-  impala: boolean
-  parquet: boolean
-  avro: boolean
+number:
+  kudu: string
+  impala: decimal
+  parquet: double
+  avro: decimal
 numeric:
   kudu: string
   impala: string
@@ -68,6 +44,53 @@ float:
   impala: float
   parquet: float
   avro: float
+long:
+  kudu: bigint
+  parquet: bigint
+  impala: bigint
+  avro: long
+smallint:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
+integer:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
+# dates
+date:
+  kudu: bigint
+  impala: bigint
+  parquet: bigint
+  avro: long
+timestamp:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+datetime:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+time_with_timezone:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+timestamp_with_timezone:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+# text
+string:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
 blob:
   kudu: string
   impala: string
@@ -88,13 +111,59 @@ varchar:
   impala: string
   parquet: string
   avro: string
-long:
-  kudu: bigint
-  parquet: bigint
-  impala: bigint
-  avro: long
 text:
   kudu: string
   impala: string
   parquet: string
   avro: string
+char:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+binary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+varbinary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longvarbinary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+nchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+nvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longnvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+# boolean
+bit:
+  kudu: boolean
+  impala: boolean
+  parquet: boolean
+  avro: boolean
+boolean:
+  kudu: boolean
+  impala: boolean
+  parquet: boolean
+  avro: boolean

--- a/templates/sqoop-parquet-hdfs-kudu-impala/type-mapping.yml
+++ b/templates/sqoop-parquet-hdfs-kudu-impala/type-mapping.yml
@@ -1,53 +1,29 @@
-date:
-  kudu: bigint
-  impala: bigint
-  parquet: bigint
-  avro: long
-timestamp:
-  kudu: bigint
-  impala: timestamp
-  parquet: bigint
-  avro: long
-datetime:
-  kudu: bigint
-  impala: timestamp
-  parquet: bigint
-  avro: long
+# numerics
 bigint:
   kudu: bigint
   impala: bigint
   parquet: bigint
   avro: long
+tinyint:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
 decimal:
   kudu: string
   impala: decimal
   parquet: double
   avro: decimal
-number:
-  kudu: string
-  impala: decimal
-  parquet: double
-  avro: decimal
-string:
-  kudu: string
-  impala: string
-  parquet: string
-  avro: string
 int:
   kudu: int
   impala: int
   parquet: int
   avro: int
-bit:
-  kudu: boolean
-  impala: boolean
-  parquet: boolean
-  avro: boolean
-boolean:
-  kudu: boolean
-  impala: boolean
-  parquet: boolean
-  avro: boolean
+number:
+  kudu: string
+  impala: decimal
+  parquet: double
+  avro: decimal
 numeric:
   kudu: string
   impala: string
@@ -68,6 +44,53 @@ float:
   impala: float
   parquet: float
   avro: float
+long:
+  kudu: bigint
+  parquet: bigint
+  impala: bigint
+  avro: long
+smallint:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
+integer:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
+# dates
+date:
+  kudu: bigint
+  impala: bigint
+  parquet: bigint
+  avro: long
+timestamp:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+datetime:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+time_with_timezone:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+timestamp_with_timezone:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+# text
+string:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
 blob:
   kudu: string
   impala: string
@@ -88,13 +111,59 @@ varchar:
   impala: string
   parquet: string
   avro: string
-long:
-  kudu: bigint
-  parquet: bigint
-  impala: bigint
-  avro: long
 text:
   kudu: string
   impala: string
   parquet: string
   avro: string
+char:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+binary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+varbinary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longvarbinary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+nchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+nvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longnvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+# boolean
+bit:
+  kudu: boolean
+  impala: boolean
+  parquet: boolean
+  avro: boolean
+boolean:
+  kudu: boolean
+  impala: boolean
+  parquet: boolean
+  avro: boolean


### PR DESCRIPTION
Pipeforge uses JDBCType to map column definitions to the data type.  Some of these were missing from the type-mapping.yml files.