### PR TITLE
Removed ` from sqoop import --query cmd

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 import unittest
 import os
 import sys
-version = '0.1.3'
+version = '0.1.4'
 
 def pipewrench_test_suite():
     test_loader = unittest.TestLoader()

--- a/templates/kudu-impala-hdfs-parquet-sqoop/type-mapping.yml
+++ b/templates/kudu-impala-hdfs-parquet-sqoop/type-mapping.yml
@@ -3,7 +3,7 @@ bigint:
   kudu: bigint
   impala: bigint
   parquet: bigint
-  avro: long
+  avro: bigint
 tinyint:
   kudu: int
   impala: int
@@ -48,7 +48,7 @@ long:
   kudu: bigint
   parquet: bigint
   impala: bigint
-  avro: long
+  avro: bigint
 smallint:
   kudu: int
   impala: int
@@ -59,32 +59,37 @@ integer:
   impala: int
   parquet: int
   avro: int
+short:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
 # dates
 date:
   kudu: bigint
   impala: bigint
   parquet: bigint
-  avro: long
+  avro: bigint
 timestamp:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 datetime:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 time_with_timezone:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 timestamp_with_timezone:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 # text
 string:
   kudu: string

--- a/templates/kudu-table-ddl/type-mapping.yml
+++ b/templates/kudu-table-ddl/type-mapping.yml
@@ -3,7 +3,7 @@ bigint:
   kudu: bigint
   impala: bigint
   parquet: bigint
-  avro: long
+  avro: bigint
 tinyint:
   kudu: int
   impala: int
@@ -48,7 +48,7 @@ long:
   kudu: bigint
   parquet: bigint
   impala: bigint
-  avro: long
+  avro: bigint
 smallint:
   kudu: int
   impala: int
@@ -59,32 +59,37 @@ integer:
   impala: int
   parquet: int
   avro: int
+short:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
 # dates
 date:
   kudu: bigint
   impala: bigint
   parquet: bigint
-  avro: long
+  avro: bigint
 timestamp:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 datetime:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 time_with_timezone:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 timestamp_with_timezone:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 # text
 string:
   kudu: string

--- a/templates/shared/type-mapping.yml
+++ b/templates/shared/type-mapping.yml
@@ -3,7 +3,7 @@ bigint:
   kudu: bigint
   impala: bigint
   parquet: bigint
-  avro: long
+  avro: bigint
 tinyint:
   kudu: int
   impala: int
@@ -48,7 +48,7 @@ long:
   kudu: bigint
   parquet: bigint
   impala: bigint
-  avro: long
+  avro: bigint
 smallint:
   kudu: int
   impala: int
@@ -59,32 +59,37 @@ integer:
   impala: int
   parquet: int
   avro: int
+short:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
 # dates
 date:
   kudu: bigint
   impala: bigint
   parquet: bigint
-  avro: long
+  avro: bigint
 timestamp:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 datetime:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 time_with_timezone:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 timestamp_with_timezone:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 # text
 string:
   kudu: string

--- a/templates/sqoop-parquet-full-load/sqoop-import.sh
+++ b/templates/sqoop-parquet-full-load/sqoop-import.sh
@@ -50,16 +50,12 @@ sqoop import \
     -m 1 \
 {%- if conf["sqoop_driver"] is defined %}
     {%- if "sqlserver" in conf["sqoop_driver"].lower() -%}
-    --query 'SELECT {% for column in table.columns%} {% if loop.last %} {{ '"{}"'.format(column.name) }} {% else %} {{ '"{}",'.format(column.name) }} {% endif %} {% endfor %}
-        FROM {{ table.source.name }} WHERE $CONDITIONS'
+    --query 'SELECT {% for column in table.columns%} {% if loop.last %} {{ '"{}"'.format(column.name) }} {% else %} {{ '"{}",'.format(column.name) }} {% endif %} {% endfor %} FROM {{ table.source.name }} WHERE $CONDITIONS'
     {%- elif "sap" in conf["sqoop_driver"].lower() -%}
-    --query 'SELECT {% for column in table.columns%} {% if loop.last %} {{ '"{}"'.format(column.name) }} {% else %} {{ '"{}",'.format(column.name) }} {% endif %} {% endfor %}
-        FROM {{ conf.source_database.name }}.{{ table.source.name }} WHERE $CONDITIONS'
+    --query 'SELECT {% for column in table.columns%} {% if loop.last %} {{ '"{}"'.format(column.name) }} {% else %} {{ '"{}",'.format(column.name) }} {% endif %} {% endfor %} FROM {{ conf.source_database.name }}.{{ table.source.name }} WHERE $CONDITIONS'
     {%- else -%}
-    --query 'SELECT {% for column in table.columns%} {% if loop.last %} {{ '`{}`'.format(column.name) }} {% else %} {{ '`{}`,'.format(column.name) }} {% endif %} {% endfor %}
-        FROM {{ conf.source_database.name }}.{{ table.source.name }} WHERE $CONDITIONS'
+    --query 'SELECT {% for column in table.columns%} {% if loop.last %} {{ column.name }}, {% else %} {{ column.name }} {% endif %} {% endfor %} FROM {{ conf.source_database.name }}.{{ table.source.name }} WHERE $CONDITIONS'
     {% endif -%}
 {%- else %}
-    --query 'SELECT {% for column in table.columns%} {% if loop.last %} {{ '`{}`'.format(column.name) }} {% else %} {{ '`{}`,'.format(column.name) }} {% endif %} {% endfor %}
-        FROM {{ conf.source_database.name }}.{{ table.source.name }} WHERE $CONDITIONS'
+    --query 'SELECT {% for column in table.columns%} {% if loop.last %} {{ column.name }} {% else %} {{ column.name }} {% endif %} {% endfor %} FROM {{ conf.source_database.name }}.{{ table.source.name }} WHERE $CONDITIONS'
 {%- endif -%}

--- a/templates/sqoop-parquet-full-load/sqoop-import.sh
+++ b/templates/sqoop-parquet-full-load/sqoop-import.sh
@@ -54,8 +54,8 @@ sqoop import \
     {%- elif "sap" in conf["sqoop_driver"].lower() -%}
     --query 'SELECT {% for column in table.columns%} {% if loop.last %} {{ '"{}"'.format(column.name) }} {% else %} {{ '"{}",'.format(column.name) }} {% endif %} {% endfor %} FROM {{ conf.source_database.name }}.{{ table.source.name }} WHERE $CONDITIONS'
     {%- else -%}
-    --query 'SELECT {% for column in table.columns%} {% if loop.last %} {{ column.name }}, {% else %} {{ column.name }} {% endif %} {% endfor %} FROM {{ conf.source_database.name }}.{{ table.source.name }} WHERE $CONDITIONS'
+    --query 'SELECT {% for column in table.columns%} {% if loop.last %} {{ column.name }} {% else %} {{ column.name }}, {% endif %} {% endfor %} FROM {{ conf.source_database.name }}.{{ table.source.name }} WHERE $CONDITIONS'
     {% endif -%}
 {%- else %}
-    --query 'SELECT {% for column in table.columns%} {% if loop.last %} {{ column.name }} {% else %} {{ column.name }} {% endif %} {% endfor %} FROM {{ conf.source_database.name }}.{{ table.source.name }} WHERE $CONDITIONS'
+    --query 'SELECT {% for column in table.columns%} {% if loop.last %} {{ column.name }} {% else %} {{ column.name }}, {% endif %} {% endfor %} FROM {{ conf.source_database.name }}.{{ table.source.name }} WHERE $CONDITIONS'
 {%- endif -%}

--- a/templates/sqoop-parquet-full-load/type-mapping.yml
+++ b/templates/sqoop-parquet-full-load/type-mapping.yml
@@ -3,7 +3,7 @@ bigint:
   kudu: bigint
   impala: bigint
   parquet: bigint
-  avro: long
+  avro: bigint
 tinyint:
   kudu: int
   impala: int
@@ -48,7 +48,7 @@ long:
   kudu: bigint
   parquet: bigint
   impala: bigint
-  avro: long
+  avro: bigint
 smallint:
   kudu: int
   impala: int
@@ -59,32 +59,37 @@ integer:
   impala: int
   parquet: int
   avro: int
+short:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
 # dates
 date:
   kudu: bigint
   impala: bigint
   parquet: bigint
-  avro: long
+  avro: bigint
 timestamp:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 datetime:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 time_with_timezone:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 timestamp_with_timezone:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 # text
 string:
   kudu: string

--- a/templates/sqoop-parquet-hdfs-hive-merge/type-mapping.yml
+++ b/templates/sqoop-parquet-hdfs-hive-merge/type-mapping.yml
@@ -1,53 +1,29 @@
-date:
-  kudu: bigint
-  impala: bigint
-  parquet: bigint
-  avro: long
-timestamp:
-  kudu: bigint
-  impala: timestamp
-  parquet: bigint
-  avro: long
-datetime:
-  kudu: bigint
-  impala: timestamp
-  parquet: bigint
-  avro: long
+# numerics
 bigint:
   kudu: bigint
   impala: bigint
   parquet: bigint
-  avro: long
+  avro: bigint
+tinyint:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
 decimal:
   kudu: string
   impala: decimal
-  parquet: double
-  avro: decimal
-number:
-  kudu: string
-  impala: decimal
-  parquet: double
-  avro: decimal
-string:
-  kudu: string
-  impala: string
-  parquet: string
+  parquet: decimal
   avro: string
 int:
   kudu: int
   impala: int
   parquet: int
   avro: int
-bit:
-  kudu: boolean
-  impala: boolean
-  parquet: boolean
-  avro: boolean
-boolean:
-  kudu: boolean
-  impala: boolean
-  parquet: boolean
-  avro: boolean
+number:
+  kudu: string
+  impala: decimal
+  parquet: decimal
+  avro: string
 numeric:
   kudu: string
   impala: string
@@ -68,6 +44,58 @@ float:
   impala: float
   parquet: float
   avro: float
+long:
+  kudu: bigint
+  parquet: bigint
+  impala: bigint
+  avro: bigint
+smallint:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
+integer:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
+short:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
+# dates
+date:
+  kudu: bigint
+  impala: bigint
+  parquet: bigint
+  avro: bigint
+timestamp:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: bigint
+datetime:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: bigint
+time_with_timezone:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: bigint
+timestamp_with_timezone:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: bigint
+# text
+string:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
 blob:
   kudu: string
   impala: string
@@ -88,13 +116,59 @@ varchar:
   impala: string
   parquet: string
   avro: string
-long:
-  kudu: bigint
-  parquet: bigint
-  impala: bigint
-  avro: long
 text:
   kudu: string
   impala: string
   parquet: string
   avro: string
+char:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+binary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+varbinary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longvarbinary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+nchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+nvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longnvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+# boolean
+bit:
+  kudu: boolean
+  impala: boolean
+  parquet: boolean
+  avro: boolean
+boolean:
+  kudu: boolean
+  impala: boolean
+  parquet: boolean
+  avro: boolean

--- a/templates/sqoop-parquet-hdfs-impala/type-mapping.yml
+++ b/templates/sqoop-parquet-hdfs-impala/type-mapping.yml
@@ -3,7 +3,7 @@ bigint:
   kudu: bigint
   impala: bigint
   parquet: bigint
-  avro: long
+  avro: bigint
 tinyint:
   kudu: int
   impala: int
@@ -48,7 +48,7 @@ long:
   kudu: bigint
   parquet: bigint
   impala: bigint
-  avro: long
+  avro: bigint
 smallint:
   kudu: int
   impala: int
@@ -59,32 +59,37 @@ integer:
   impala: int
   parquet: int
   avro: int
+short:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
 # dates
 date:
   kudu: bigint
   impala: bigint
   parquet: bigint
-  avro: long
+  avro: bigint
 timestamp:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 datetime:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 time_with_timezone:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 timestamp_with_timezone:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 # text
 string:
   kudu: string

--- a/templates/sqoop-parquet-hdfs-kudu-impala/type-mapping.yml
+++ b/templates/sqoop-parquet-hdfs-kudu-impala/type-mapping.yml
@@ -3,7 +3,7 @@ bigint:
   kudu: bigint
   impala: bigint
   parquet: bigint
-  avro: long
+  avro: bigint
 tinyint:
   kudu: int
   impala: int
@@ -48,7 +48,7 @@ long:
   kudu: bigint
   parquet: bigint
   impala: bigint
-  avro: long
+  avro: bigint
 smallint:
   kudu: int
   impala: int
@@ -59,32 +59,37 @@ integer:
   impala: int
   parquet: int
   avro: int
+short:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
 # dates
 date:
   kudu: bigint
   impala: bigint
   parquet: bigint
-  avro: long
+  avro: bigint
 timestamp:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 datetime:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 time_with_timezone:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 timestamp_with_timezone:
   kudu: bigint
   impala: timestamp
   parquet: bigint
-  avro: long
+  avro: bigint
 # text
 string:
   kudu: string


### PR DESCRIPTION
- Fixed avro type mapping

In the sqoop-parquet-full-load template the default for sqoop query was wrapping column names in backticks, this caused query syntax errors in various source systems.

Long data types are not supported in hive/impala tables changed type mapping to bigint.