### PR TITLE
Changes to support Kudu partitioning based on part of the PK, also su…

### DIFF
--- a/templates/shared/kudu-table-create.sql
+++ b/templates/shared/kudu-table-create.sql
@@ -21,7 +21,18 @@ CREATE TABLE IF NOT EXISTS {{ table.destination.name }}_kudu
 {%- if not loop.last -%},{% endif %}
 {%- endfor %},
 primary key ({{ table.primary_keys|join(', ') }}))
-PARTITION BY HASH({{ table.kudu.hash_by|join(', ') }}) PARTITIONS {{ table.kudu.num_partitions }}
+{%- if table.kudu.hash_by or table.kudu.range %}
+  PARTITION BY
+{%- endif %}
+{%- if table.kudu.hash_by %}
+  HASH({{ table.kudu.hash_by|join(', ') }}) PARTITIONS {{ table.kudu.num_partitions }} {%- if table.kudu.range %} ,{%- endif %}
+{%- endif %}
+{%- if table.kudu.range %}
+ RANGE ({{ table.kudu.range|join(', ') }})
+ (
+   {{ table.kudu.ranges|join(', ') }}
+ )
+{%- endif %}
 COMMENT '{{ table.comment }}'
 STORED AS KUDU
 TBLPROPERTIES(


### PR DESCRIPTION
Supports Range partitioning

```
 kudu:
    range:
    - from_date
    ranges:
      - PARTITION 20170101 <= VALUES < 20180101
      - PARTITION 20180101 <= VALUES < 20181231
      - PARTITION 20190201 <= VALUES < 20191231
```

Also, support a combination of HASH and RANGE partitioning

```
  kudu:
    hash_by:
    - emp_no
    num_partitions: 2
    range:
    - from_date
    ranges:
      - PARTITION VALUES < 20180101
      - PARTITION 20180101 <= VALUES < 20181231
      - PARTITION 20190201 <= VALUES < 20191231
```

Also, supports non-partitioned Kudu tables via:

```
kudu:
```