### PR TITLE
Add Alter Table and Product View Templates, As well as remove hard coded _kudu / _parquet

### DIFF
--- a/templates/kudu-table-ddl/Makefile
+++ b/templates/kudu-table-ddl/Makefile
@@ -25,6 +25,11 @@ kudu-table-clean: kudu-table-drop.sql ## Drop Kudu table
 
 tables-clean: kudu-table-clean  ## Drop all tables
 
+kudu-table-alter: kudu-table-alter.sql ## Alter Kudu table
+	$(impala-cmd) kudu-table-alter.sql
+
+tables-alter: kudu-table-alter  ## Alter all tables
+
 tables: kudu-table ## Create all tables
 
 integration-test: # Run integration-tests

--- a/templates/kudu-table-ddl/Makefile.meta
+++ b/templates/kudu-table-ddl/Makefile.meta
@@ -26,6 +26,13 @@ tables-clean-{{ table.id }}:
 	$(MAKE) tables-clean -C {{ table.id }}
 {%- endfor %}
 
+tables-alter-all: {%- for table in tables %} tables-alter-{{ table.id }} {%- endfor %}
+
+{%- for table in tables %}
+tables-alter-{{ table.id }}:
+	$(MAKE) tables-alter -C {{ table.id }}
+{%- endfor %}
+
 tables-compute-stats-all: {%- for table in tables %} tables-compute-stats-{{ table.id }} {%- endfor %}
 
 {%- for table in tables %}

--- a/templates/kudu-table-ddl/compute-stats.sql
+++ b/templates/kudu-table-ddl/compute-stats.sql
@@ -14,5 +14,5 @@
 -#}
 -- Compute table stats for optimized joins
 USE {{ conf.staging_database.name }};
-COMPUTE STATS {{ table.destination.name }}_kudu;
+COMPUTE STATS {{ table.destination.name }}{% if conf.user_defined is defined and conf.user_defined.kudu_suffix is defined %}{{ conf.user_defined.kudu_suffix }}{% endif %};
 

--- a/templates/kudu-table-ddl/imports
+++ b/templates/kudu-table-ddl/imports
@@ -3,3 +3,4 @@
 ../shared/run-with-logging.sh
 ../shared/kudu-table-drop.sql
 ../shared/kudu-table-create.sql
+../shared/kudu-table-alter.sql

--- a/templates/product-view-ddl/Makefile
+++ b/templates/product-view-ddl/Makefile
@@ -1,0 +1,24 @@
+{#  Copyright 2017 Cargill Incorporated
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License. #}
+
+impala-cmd={{ conf.impala_cmd }}
+
+product-view: product-view-create.sql ## Create Impala Kudu Table
+	$(impala-cmd) product-view-create.sql
+
+views: product-view ## Create all tables
+
+
+help:  ## Print help message
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'

--- a/templates/product-view-ddl/Makefile.meta
+++ b/templates/product-view-ddl/Makefile.meta
@@ -1,0 +1,22 @@
+{#  Copyright 2017 Cargill Incorporated
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License. #}
+
+views-all: {%- for table in tables %} views-{{ table.id }} {%- endfor %}
+
+{%- for table in tables %}
+tables-{{ table.id }}:
+	$(MAKE) views -C {{ table.id }}
+{%- endfor %}
+
+

--- a/templates/product-view-ddl/imports
+++ b/templates/product-view-ddl/imports
@@ -1,0 +1,1 @@
+../shared/product-view-create.sql

--- a/templates/product-view-ddl/type-mapping.yml
+++ b/templates/product-view-ddl/type-mapping.yml
@@ -1,0 +1,169 @@
+# numerics
+bigint:
+  kudu: bigint
+  impala: bigint
+  parquet: bigint
+  avro: long
+tinyint:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
+decimal:
+  kudu: string
+  impala: decimal
+  parquet: decimal
+  avro: string
+int:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
+number:
+  kudu: string
+  impala: decimal
+  parquet: decimal
+  avro: string
+numeric:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+double:
+  kudu: double
+  impala: double
+  parquet: double
+  avro: string
+real:
+  kudu: string
+  impala: decimal
+  parquet: string
+  avro: string
+float:
+  kudu: float
+  impala: float
+  parquet: float
+  avro: float
+long:
+  kudu: bigint
+  parquet: bigint
+  impala: bigint
+  avro: long
+smallint:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
+integer:
+  kudu: int
+  impala: int
+  parquet: int
+  avro: int
+# dates
+date:
+  kudu: bigint
+  impala: bigint
+  parquet: bigint
+  avro: long
+timestamp:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+datetime:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+time_with_timezone:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+timestamp_with_timezone:
+  kudu: bigint
+  impala: timestamp
+  parquet: bigint
+  avro: long
+# text
+string:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+blob:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+clob:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+nclob:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+varchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+text:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+char:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+binary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+varbinary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longvarbinary:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+nchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+nvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+longnvarchar:
+  kudu: string
+  impala: string
+  parquet: string
+  avro: string
+# boolean
+bit:
+  kudu: boolean
+  impala: boolean
+  parquet: boolean
+  avro: boolean
+boolean:
+  kudu: boolean
+  impala: boolean
+  parquet: boolean
+  avro: boolean

--- a/templates/shared/kudu-table-alter.sql
+++ b/templates/shared/kudu-table-alter.sql
@@ -14,17 +14,8 @@
 -#}
 -- Create a Kudu table in Impala
 USE {{ conf.staging_database.name }};
-CREATE TABLE IF NOT EXISTS {{ table.destination.name }}{% if conf.user_defined is defined and conf.user_defined.kudu_suffix is defined %}{{ conf.user_defined.kudu_suffix }}{% endif %}
-{%- set ordered_columns = order_columns(table.primary_keys,table.columns) -%}
-({%- for column in ordered_columns %}
-        `{{ cleanse_column(column.name) }}` {{ map_datatypes(column).kudu }}
-{%- if not loop.last -%},{% endif %}
-{%- endfor %},
-primary key ({{ table.primary_keys|join(', ') }}))
-PARTITION BY HASH({{ table.kudu.hash_by|join(', ') }}) PARTITIONS {{ table.kudu.num_partitions }}
-COMMENT '{{ table.comment }}'
-STORED AS KUDU
-TBLPROPERTIES(
+ALTER TABLE  {{ table.destination.name }}{% if conf.user_defined is defined and conf.user_defined.kudu_suffix is defined %}{{ conf.user_defined.kudu_suffix }}{% endif %}
+SET TBLPROPERTIES(
 {%- if table.metadata %}
   {%- for key, value in table.metadata.items() %}
   '{{ key }}' = '{{ value }}',

--- a/templates/shared/kudu-table-drop.sql
+++ b/templates/shared/kudu-table-drop.sql
@@ -15,4 +15,4 @@
 
 -- Drop the Kudu table
 USE {{ conf.staging_database.name }};
-DROP TABLE IF EXISTS {{ table.destination.name }}_kudu PURGE;
+DROP TABLE IF EXISTS {{ table.destination.name }}{% if conf.user_defined is defined and conf.user_defined.kudu_suffix is defined %}{{ conf.user_defined.kudu_suffix }}{% endif %} PURGE;

--- a/templates/shared/kudu-table-rowcount.sql
+++ b/templates/shared/kudu-table-rowcount.sql
@@ -13,5 +13,5 @@
     limitations under the License. #}
 
 USE {{ conf.staging_database.name }};
-INVALIDATE METADATA {{ table.destination.name }}_kudu;
-SELECT COUNT(*) FROM {{ table.destination.name }}_kudu;
+INVALIDATE METADATA {{ table.destination.name }}{% if conf.user_defined is defined and conf.user_defined.kudu_suffix is defined %}{{ conf.user_defined.kudu_suffix }}{% endif %};
+SELECT COUNT(*) FROM {{ table.destination.name }}{% if conf.user_defined is defined and conf.user_defined.kudu_suffix is defined %}{{ conf.user_defined.kudu_suffix }}{% endif %};

--- a/templates/shared/parquet-refresh.sql
+++ b/templates/shared/parquet-refresh.sql
@@ -15,4 +15,4 @@
 -- Create a Parquet table in Impala
 SET SYNC_DDL=1;
 USE {{ conf.staging_database.name }};
-REFRESH {{ table.destination.name }}_parquet;
+REFRESH {{ table.destination.name }}{% if conf.user_defined is defined and conf.user_defined.parquet_suffix is defined %}{{ conf.user_defined.parquet_suffix }}{% endif %};

--- a/templates/shared/parquet-table-alter.sql
+++ b/templates/shared/parquet-table-alter.sql
@@ -15,16 +15,14 @@
 -- Create a Parquet table in Impala
 set sync_ddl=1;
 USE {{ conf.staging_database.name }};
-CREATE EXTERNAL TABLE IF NOT EXISTS {{ table.destination.name }}{% if conf.user_defined is defined and conf.user_defined.parquet_suffix is defined %}{{ conf.user_defined.parquet_suffix }}{% endif %} (
 {%- for column in table.columns %}
-{{ cleanse_column(column.name) }} {{ map_datatypes(column).parquet }} COMMENT "{{ column.comment }}"
-{%- if not loop.last -%}, {% endif %}
+ALTER TABLE {{ table.destination.name }}{% if conf.user_defined is defined and conf.user_defined.parquet_suffix is defined %}{{ conf.user_defined.parquet_suffix }}{% endif %}
+CHANGE {{ cleanse_column(column.name) }} {{ cleanse_column(column.name) }} {{ map_datatypes(column).parquet }} COMMENT "{{ column.comment }}";
 {%- endfor %})
-COMMENT '{{ table.comment }}'
-STORED AS Parquet
-LOCATION '{{ conf.staging_database.path }}/{{ table.destination.name }}/incr'
+
 {%- if table.metadata %}  
-TBLPROPERTIES(
+ALTER TABLE {{ table.destination.name }}{% if conf.user_defined is defined and conf.user_defined.parquet_suffix is defined %}{{ conf.user_defined.parquet_suffix }}{% endif %} 
+SET TBLPROPERTIES (
   {%- for key, value in table.metadata.items() %}
   '{{ key }}' = '{{ value }}'{%- if not loop.last -%}, {% endif %}
   {%- endfor %}

--- a/templates/shared/parquet-table-drop.sql
+++ b/templates/shared/parquet-table-drop.sql
@@ -14,4 +14,4 @@
 
 -- Drop the Impala Parquet table
 USE {{ conf.staging_database.name }};
-DROP TABLE IF EXISTS {{ table.destination.name }}_parquet;
+DROP TABLE IF EXISTS {{ table.destination.name }}{% if conf.user_defined is defined and conf.user_defined.parquet_suffix is defined %}{{ conf.user_defined.parquet_suffix }}{% endif %};

--- a/templates/shared/parquet-table-rowcount.sql
+++ b/templates/shared/parquet-table-rowcount.sql
@@ -14,6 +14,6 @@
 
 -- Query Parquet table in Impala
 USE {{ conf.staging_database.name }};
-INVALIDATE METADATA {{ table.destination.name }}_parquet;
-SELECT COUNT(*) FROM {{ table.destination.name }}_parquet;
+INVALIDATE METADATA {{ table.destination.name }}{% if conf.user_defined is defined and conf.user_defined.parquet_suffix is defined %}{{ conf.user_defined.parquet_suffix }}{% endif %};
+SELECT COUNT(*) FROM {{ table.destination.name }}{% if conf.user_defined is defined and conf.user_defined.parquet_suffix is defined %}{{ conf.user_defined.parquet_suffix }}{% endif %};
 

--- a/templates/shared/product-view-create.sql
+++ b/templates/shared/product-view-create.sql
@@ -1,0 +1,35 @@
+{#-  Copyright 2017 Cargill Incorporated
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-#}
+-- Create a view in Impala
+
+USE {% if conf.user_defined is defined and conf.user_defined.product_database is defined %}{{ conf.user_defined.product_database }}
+{% else %}{{ conf.staging_database.name }}{% endif %};
+CREATE VIEW IF NOT EXISTS {{ table.destination.name }}{% if conf.user_defined is defined and conf.user_defined.view_suffix is defined %}{{ conf.user_defined.view_suffix }}{% endif %} 
+({%- for column in table.columns %}`{{ cleanse_column(column.name) }}` COMMENT "{{ column.comment }}"
+{%- if not loop.last -%}, {% endif %}{%- endfor %})
+COMMENT '{{ table.comment }}'
+AS
+SELECT 
+{%- set ordered_columns = order_columns(table.primary_keys,table.columns) -%}
+{%- for column in ordered_columns %}
+        {% if column.datatype == "DECIMAL" %}CAST(`{{ cleanse_column(column.name) }}` AS DECIMAL ({{ column.precision }},{{ column.scale }})) AS `{{ cleanse_column(column.name) }}`{% else %}`{{ cleanse_column(column.name) }}`{% endif %}
+{%- if not loop.last -%},{% endif %}
+{%- endfor %}
+FROM {{ conf.staging_database.name }}.{{ table.destination.name }}{% if conf.user_defined is defined and conf.user_defined.view_suffix is defined %}{{ conf.user_defined.view_suffix }}{% endif %} 
+{#- 
+The FROM logic is subject to change, I was not certain whether if no Product datbase was provided if we should still source from the staging database
+FROM {% if conf.user_defined.product_database is defined %}{{ conf.staging_database.name }}{% else %}{{ conf.raw_database.name }}{% endif %}.{{ table.destination.name }}{{ conf.user_defined.kudu_suffix }}    
+-#}
+

--- a/templates/sqoop-parquet-hdfs-impala/Makefile
+++ b/templates/sqoop-parquet-hdfs-impala/Makefile
@@ -52,6 +52,8 @@ hdfs-clean: hdfs-delete.sh ## Delete parquet files from HDFS
 
 tables-clean: parquet-table-clean ## Drop all tables
 
+tables-alter: parquet-table-alter ## Alter all tables
+
 tables: parquet-table ## Create all tables
 
 update: sqoop-exec ## Insert data from source db into Kudu

--- a/templates/sqoop-parquet-hdfs-impala/Makefile.meta
+++ b/templates/sqoop-parquet-hdfs-impala/Makefile.meta
@@ -48,3 +48,10 @@ integration-test-all:
 {%- for table in tables %}
 	$(MAKE) integration-test -C {{ table.id }}
 {%- endfor %}
+
+tables-alter-all: {%- for table in tables %} tables-alter-{{ table.id }} {%- endfor %}
+
+{%- for table in tables %}
+tables-alter-{{ table.id }}:
+	$(MAKE) tables-alter -C {{ table.id }}
+{%- endfor %}

--- a/templates/sqoop-parquet-hdfs-impala/imports
+++ b/templates/sqoop-parquet-hdfs-impala/imports
@@ -7,6 +7,7 @@
 ../shared/parquet-table-drop.sql
 ../shared/parquet-table-create.sql
 ../shared/parquet-table-rowcount.sql
+../shared/parquet-table-alter.sql
 ../shared/source-table-rowcount.sql
 ../shared/hdfs-unarchive.sh
 ../shared/hdfs-delete.sh


### PR DESCRIPTION
I replaced the hard coded kudu/parquet suffixes with an optional user defined parameter.

New Template to create a view over a Kudu table that casts decimal columns back into decimals

Added a Alter table which can be used to update metadata on the main Kudu and Parquet templates.