### PR TITLE
Updated `map_datatypes` to add precision and scale for decimal types

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,11 @@ $ ../shared/sqoop-create.sh
 ```
 
 ### Mapping datatypes
+
+#### Version 2: map_datatypes_v2(column, storage_format)
+Version 1 of the map_datatypes function does not specify precision and scale when mapping decimal data types.  Version 2 fixes this by returning the string representation (ie DECIMAL(10,2), STRING, etc) of the mapped data type. `storage_format` (kudu, impala, parquet, avro) is used to map the incoming database type with the format specified in the `type-mapping.yml` file.
+
+#### Version 1 (deprecated): map_datatypes(column).format
 Data type mappings from the source to destination database are defined in these configuration properties:
 
 ```snakeyaml

--- a/README.md
+++ b/README.md
@@ -273,8 +273,9 @@ $ ../shared/sqoop-create.sh
 Version 1 of the map_datatypes function does not specify precision and scale when mapping decimal data types.  Version 2 fixes this by returning the string representation (ie DECIMAL(10,2), STRING, etc) of the mapped data type. `storage_format` (kudu, impala, parquet, avro) is used to map the incoming database type with the format specified in the `type-mapping.yml` file.
 
 #### Version 1 (deprecated): map_datatypes(column).format
-Data type mappings from the source to destination database are defined in these configuration properties:
+Data type mappings from the source to destination database
 
+#### Configuration properties
 ```snakeyaml
 type_mapping: type-mapping.yml # Type mapping used for database type conversion
 ```

--- a/pipewrench/merge.py
+++ b/pipewrench/merge.py
@@ -201,7 +201,8 @@ def render(template, **kwargs):
     :return: The reified template
     """
     template = Template(template)
-    template_functions = [map_datatypes, dumps, map_clobs, order_columns, cleanse_column]
+    template_functions = [map_datatypes, map_datatypes_v2, dumps,
+                          map_clobs, order_columns, cleanse_column]
 
     for function in template_functions:
         template.globals[function.__name__] = function

--- a/pipewrench/merge.py
+++ b/pipewrench/merge.py
@@ -294,7 +294,8 @@ def map_datatypes(column, storage_format):
     mapped_datatype = mapped_datatype_dic.get(storage_format)
     if mapped_datatype:
         if mapped_datatype.lower() == 'decimal':
-            mapped_datatype = 'DECIMAL({precision}, {scale})'.format(precision=column['precision'], scale=column['scale'])
+            mapped_datatype = 'DECIMAL({precision}, {scale})'.format(
+                precision=column['precision'], scale=column['scale'])
     else:
         mapped_datatype = 'STRING'
     logging.debug('mapped %s to %s', datatype, mapped_datatype)

--- a/pipewrench/merge.py
+++ b/pipewrench/merge.py
@@ -261,10 +261,36 @@ def write(string, fpath):
 if __name__ == '__main__':
     main()
 
-
 # Template functions.
 # These functions are intended to be called from Jinja2 templates.
-def map_datatypes(column, storage_format):
+def map_datatypes(column):
+    """
+    Given a column, extract its datatype and return possible mappings
+     for it from a type-mappings.yml file.
+     For example, a mapping with the datatype 'bigint' may look like:
+    bigint:
+     kudu: bigint
+     impala: bigint
+     parquet: bigint
+     avro: long
+     when given a column with 'bigint' this function will return:
+     kudu: bigint
+     impala: bigint
+     parquet: bigint
+     avro: long
+    This function is intended to be called directly from templates
+    :param conf: The configuration. Not used but kept for consistency with other functions.
+    :param column: The column containing the datatype to map
+    :return: The mapped datatype
+    """
+    datatype = column['datatype'].lower()
+    logging.debug('found datatype %s', datatype)
+    mapped_datatype = type_mappings['type_mapping'].get(datatype)
+    logging.debug('mapped %s to %s', datatype, mapped_datatype)
+    return mapped_datatype
+
+
+def map_datatypes_v2(column, storage_format):
     """
     Given a column, extract its datatype and return possible mappings
      for it from a type-mappings.yml file.

--- a/pipewrench/merge_test.py
+++ b/pipewrench/merge_test.py
@@ -28,4 +28,4 @@ class MergeTest(unittest.TestCase):
         merge.type_mappings = {'type_mapping': {'blob': {'kudu': 'string'}}}
         values = {'conf': 'nevermind', 'column': {'datatype': 'blob'}}
 
-        assert 'string' == merge.render("{{ map_datatypes(column).kudu }}", **values)
+        assert 'string' == merge.render("{{ map_datatypes(column, 'kudu') }}", **values)

--- a/pipewrench/merge_test.py
+++ b/pipewrench/merge_test.py
@@ -28,4 +28,4 @@ class MergeTest(unittest.TestCase):
         merge.type_mappings = {'type_mapping': {'blob': {'kudu': 'string'}}}
         values = {'conf': 'nevermind', 'column': {'datatype': 'blob'}}
 
-        assert 'string' == merge.render("{{ map_datatypes(column, 'kudu') }}", **values)
+        assert 'string' == merge.render("{{ map_datatypes(column).kudu }}", **values)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 import unittest
 import os
 import sys
-version = '0.1.5'
+version = '0.1.6'
 
 def pipewrench_test_suite():
     test_loader = unittest.TestLoader()

--- a/templates/shared/kudu-table-create.sql
+++ b/templates/shared/kudu-table-create.sql
@@ -17,7 +17,7 @@ USE {{ conf.staging_database.name }};
 CREATE TABLE IF NOT EXISTS {{ table.destination.name }}_kudu
 {%- set ordered_columns = order_columns(table.primary_keys,table.columns) -%}
 ({%- for column in ordered_columns %}
-        {{ column.name }} {{ map_datatypes(column).kudu }}
+        {{ column.name }} {{ map_datatypes(column, 'kudu') }}
 {%- if not loop.last -%},{% endif %}
 {%- endfor %},
 primary key ({{ table.primary_keys|join(', ') }}))

--- a/templates/shared/kudu-table-create.sql
+++ b/templates/shared/kudu-table-create.sql
@@ -17,7 +17,7 @@ USE {{ conf.staging_database.name }};
 CREATE TABLE IF NOT EXISTS {{ table.destination.name }}_kudu
 {%- set ordered_columns = order_columns(table.primary_keys,table.columns) -%}
 ({%- for column in ordered_columns %}
-        {{ column.name }} {{ map_datatypes(column, 'kudu') }}
+        {{ column.name }} {{ map_datatypes_v2(column, 'kudu') }}
 {%- if not loop.last -%},{% endif %}
 {%- endfor %},
 primary key ({{ table.primary_keys|join(', ') }}))

--- a/templates/shared/parquet-table-create.sql
+++ b/templates/shared/parquet-table-create.sql
@@ -17,7 +17,7 @@ set sync_ddl=1;
 USE {{ conf.staging_database.name }};
 CREATE EXTERNAL TABLE IF NOT EXISTS {{ table.destination.name }}_parquet (
 {%- for column in table.columns %}
-{{ column.name }} {{ map_datatypes(column).parquet }} COMMENT "{{ column.comment }}"
+{{ column.name }} {{ map_datatypes(column, 'parquet') }} COMMENT "{{ column.comment }}"
 {%- if not loop.last -%}, {% endif %}
 {%- endfor %})
 COMMENT '{{ table.comment }}'

--- a/templates/shared/parquet-table-create.sql
+++ b/templates/shared/parquet-table-create.sql
@@ -17,7 +17,7 @@ set sync_ddl=1;
 USE {{ conf.staging_database.name }};
 CREATE EXTERNAL TABLE IF NOT EXISTS {{ table.destination.name }}_parquet (
 {%- for column in table.columns %}
-{{ column.name }} {{ map_datatypes(column, 'parquet') }} COMMENT "{{ column.comment }}"
+{{ column.name }} {{ map_datatypes_v2(column, 'parquet') }} COMMENT "{{ column.comment }}"
 {%- if not loop.last -%}, {% endif %}
 {%- endfor %})
 COMMENT '{{ table.comment }}'

--- a/templates/shared/textfile-table-create.sql
+++ b/templates/shared/textfile-table-create.sql
@@ -16,7 +16,7 @@
 USE {{ conf.staging_database.name }};
 CREATE EXTERNAL TABLE IF NOT EXISTS {{ table.destination.name }}_parquet (
 {% for column in table.columns %}
-{{ column.name }} {{ map_datatypes(column, 'parquet') }} COMMENT "{{ column.comment }}"
+{{ column.name }} {{ map_datatypes_v2(column, 'parquet') }} COMMENT "{{ column.comment }}"
 {%- if not loop.last -%}, {% endif %}
 {%- endfor %})
 ROW FORMAT DELIMITED

--- a/templates/shared/textfile-table-create.sql
+++ b/templates/shared/textfile-table-create.sql
@@ -16,7 +16,7 @@
 USE {{ conf.staging_database.name }};
 CREATE EXTERNAL TABLE IF NOT EXISTS {{ table.destination.name }}_parquet (
 {% for column in table.columns %}
-{{ column.name }} {{ map_datatypes(column).parquet }} COMMENT "{{ column.comment }}"
+{{ column.name }} {{ map_datatypes(column, 'parquet') }} COMMENT "{{ column.comment }}"
 {%- if not loop.last -%}, {% endif %}
 {%- endfor %})
 ROW FORMAT DELIMITED

--- a/templates/sqoop-parquet-full-load/avro-table-create.sql
+++ b/templates/sqoop-parquet-full-load/avro-table-create.sql
@@ -16,9 +16,8 @@
 set sync_ddl=1;
 USE {{ conf.raw_database.name }};
 CREATE EXTERNAL TABLE IF NOT EXISTS {{ table.destination.name }}_avro (
-{% for column in table.columns %}
-`{{ column.name.replace('/','_') }}` {{ map_datatypes(column).avro }} COMMENT "{{ column.comment }}"
-{%- if not loop.last -%}, {% endif %}
+{%- for column in table.columns %}
+`{{ cleanse_column(column.name) }}` {{ map_datatypes(column, 'avro') }} COMMENT "{{ column.comment }}"{%- if not loop.last -%}, {% endif %}
 {%- endfor %})
 COMMENT '{{ table.comment }}'
 STORED AS AVRO

--- a/templates/sqoop-parquet-full-load/avro-table-create.sql
+++ b/templates/sqoop-parquet-full-load/avro-table-create.sql
@@ -17,7 +17,7 @@ set sync_ddl=1;
 USE {{ conf.raw_database.name }};
 CREATE EXTERNAL TABLE IF NOT EXISTS {{ table.destination.name }}_avro (
 {%- for column in table.columns %}
-`{{ cleanse_column(column.name) }}` {{ map_datatypes(column, 'avro') }} COMMENT "{{ column.comment }}"{%- if not loop.last -%}, {% endif %}
+`{{ cleanse_column(column.name) }}` {{ map_datatypes_v2(column, 'avro') }} COMMENT "{{ column.comment }}"{%- if not loop.last -%}, {% endif %}
 {%- endfor %})
 COMMENT '{{ table.comment }}'
 STORED AS AVRO

--- a/templates/sqoop-parquet-full-load/partitioned-table-create.sql
+++ b/templates/sqoop-parquet-full-load/partitioned-table-create.sql
@@ -16,12 +16,8 @@
 set sync_ddl=1;
 USE {{ conf.raw_database.name }};
 CREATE EXTERNAL TABLE IF NOT EXISTS {{ table.destination.name }}_partitioned (
-{% for column in table.columns %}
-{%- if column["datatype"].lower() == "decimal" %}
-`{{ column.name.replace('/','_') }}` {{ map_datatypes(column).parquet }}({{column.precision}},{{column.scale}}) COMMENT "{{ column.comment }}"
-{%- else %} `{{ column.name.replace('/','_') }}` {{ map_datatypes(column).parquet }} COMMENT "{{ column.comment }}"
-{% endif %}
-{%- if not loop.last -%}, {% endif %}
+{%- for column in table.columns %}
+`{{ cleanse_column(column.name) }}` {{ map_datatypes(column, 'parquet') }} COMMENT "{{ column.comment }}" {%- if not loop.last -%}, {% endif %}
 {%- endfor %})
 PARTITIONED BY (ingest_partition int)
 COMMENT '{{ table.comment }}'

--- a/templates/sqoop-parquet-full-load/partitioned-table-create.sql
+++ b/templates/sqoop-parquet-full-load/partitioned-table-create.sql
@@ -17,7 +17,7 @@ set sync_ddl=1;
 USE {{ conf.raw_database.name }};
 CREATE EXTERNAL TABLE IF NOT EXISTS {{ table.destination.name }}_partitioned (
 {%- for column in table.columns %}
-`{{ cleanse_column(column.name) }}` {{ map_datatypes(column, 'parquet') }} COMMENT "{{ column.comment }}" {%- if not loop.last -%}, {% endif %}
+`{{ cleanse_column(column.name) }}` {{ map_datatypes_v2(column, 'parquet') }} COMMENT "{{ column.comment }}" {%- if not loop.last -%}, {% endif %}
 {%- endfor %})
 PARTITIONED BY (ingest_partition int)
 COMMENT '{{ table.comment }}'

--- a/templates/sqoop-parquet-full-load/report-table-create.sql
+++ b/templates/sqoop-parquet-full-load/report-table-create.sql
@@ -17,7 +17,7 @@ set sync_ddl=1;
 USE {{ conf.staging_database.name }};
 CREATE EXTERNAL TABLE IF NOT EXISTS {{ table.destination.name }} (
 {%- for column in table.columns %}
-`{{ cleanse_column(column.name) }}` {{ map_datatypes(column, 'parquet') }} COMMENT "{{ column.comment }}" {%- if not loop.last -%}, {% endif %}
+`{{ cleanse_column(column.name) }}` {{ map_datatypes_v2(column, 'parquet') }} COMMENT "{{ column.comment }}" {%- if not loop.last -%}, {% endif %}
 {%- endfor %})
 COMMENT '{{ table.comment }}'
 STORED AS PARQUET

--- a/templates/sqoop-parquet-full-load/report-table-create.sql
+++ b/templates/sqoop-parquet-full-load/report-table-create.sql
@@ -16,12 +16,8 @@
 set sync_ddl=1;
 USE {{ conf.staging_database.name }};
 CREATE EXTERNAL TABLE IF NOT EXISTS {{ table.destination.name }} (
-{% for column in table.columns %}
-{%- if column["datatype"].lower() == "decimal" %}
-`{{ column.name.replace('/','_') }}` {{ map_datatypes(column).parquet }}({{column.precision}},{{column.scale}}) COMMENT "{{ column.comment }}"
-{%- else %} `{{ column.name.replace('/','_') }}` {{ map_datatypes(column).parquet }} COMMENT "{{ column.comment }}"
-{% endif %}
-{%- if not loop.last -%}, {% endif %}
+{%- for column in table.columns %}
+`{{ cleanse_column(column.name) }}` {{ map_datatypes(column, 'parquet') }} COMMENT "{{ column.comment }}" {%- if not loop.last -%}, {% endif %}
 {%- endfor %})
 COMMENT '{{ table.comment }}'
 STORED AS PARQUET

--- a/templates/sqoop-parquet-hdfs-hive-merge/create-base-table.sql
+++ b/templates/sqoop-parquet-hdfs-hive-merge/create-base-table.sql
@@ -17,7 +17,7 @@ USE {{ conf.staging_database.name }};
 
 CREATE EXTERNAL TABLE IF NOT EXISTS {{ table.destination.name }}_base (
   {% for column in table.columns %}
-  {{ column.name }} {{ map_datatypes(column).parquet }} COMMENT "{{ column.comment }}"
+  {{ column.name }} {{ map_datatypes_v2(column, 'parquet') }} COMMENT "{{ column.comment }}"
   {%- if not loop.last -%}, {% endif %}
   {%- endfor %})
 STORED AS Parquet

--- a/templates/sqoop-parquet-hdfs-hive-merge/create-incr-table.sql
+++ b/templates/sqoop-parquet-hdfs-hive-merge/create-incr-table.sql
@@ -18,7 +18,7 @@ USE {{ conf.staging_database.name }};
 --Create incr table--
 CREATE EXTERNAL TABLE IF NOT EXISTS {{ table.destination.name }}_incr (
   {% for column in table.columns %}
-  {{ column.name }} {{ map_datatypes(column).parquet }} COMMENT "{{ column.comment }}"
+  {{ column.name }} {{ map_datatypes_v2(column, 'parquet') }} COMMENT "{{ column.comment }}"
   {%- if not loop.last -%}, {% endif %}
   {%- endfor %})
 STORED AS Parquet

--- a/templates/sqoop-parquet-hdfs-hive-merge/create-report-table.sql
+++ b/templates/sqoop-parquet-hdfs-hive-merge/create-report-table.sql
@@ -30,7 +30,7 @@ AS SELECT * FROM {{ conf.staging_database.name}}.{{ table.destination.name }}_me
 -- create table, then insert overwrite --
 CREATE EXTERNAL TABLE IF NOT EXISTS {{ table.destination.name }}_report (
   {% for column in table.columns %}
-  {{ column.name }} {{ map_datatypes(column).parquet }} COMMENT "{{ column.comment }}"
+  {{ column.name }} {{ map_datatypes(column, 'parquet') }} COMMENT "{{ column.comment }}"
   {%- if not loop.last -%}, {% endif %}
   {%- endfor %})
 STORED AS Parquet

--- a/templates/sqoop-parquet-hdfs-hive-merge/create-report-table.sql
+++ b/templates/sqoop-parquet-hdfs-hive-merge/create-report-table.sql
@@ -30,7 +30,7 @@ AS SELECT * FROM {{ conf.staging_database.name}}.{{ table.destination.name }}_me
 -- create table, then insert overwrite --
 CREATE EXTERNAL TABLE IF NOT EXISTS {{ table.destination.name }}_report (
   {% for column in table.columns %}
-  {{ column.name }} {{ map_datatypes(column, 'parquet') }} COMMENT "{{ column.comment }}"
+  {{ column.name }} {{ map_datatypes_v2(column, 'parquet') }} COMMENT "{{ column.comment }}"
   {%- if not loop.last -%}, {% endif %}
   {%- endfor %})
 STORED AS Parquet


### PR DESCRIPTION
Previously when a decimal data type was mapped the output would just
contain `decimal`.  Now decimal datatypes will have the precision and
scale added to table ddl statements.