### PR TITLE
Adding num_mappers to templates

### DIFF
--- a/templates/shared/sqoop-create.sh
+++ b/templates/shared/sqoop-create.sh
@@ -35,7 +35,7 @@ sqoop job -D 'sqoop.metastore.client.record.password=true' \
     --fetch-size 10000 \
     --compress  \
     --compression-codec snappy \
-    -m 1 \
+    -m {{ table.num_mappers or 1 }} \
     --query 'SELECT {{ table.columns|map(attribute='name')|join(',\n\t')}}
         FROM {{ conf.source_database.name }}.{{ table.source.name }} WHERE $CONDITIONS'
 

--- a/templates/sqoop-parquet-full-load/sqoop-import.sh
+++ b/templates/sqoop-parquet-full-load/sqoop-import.sh
@@ -47,7 +47,7 @@ sqoop import \
     --fetch-size {% if table.columns|length < 30 -%} 10000 {% else %} 5000 {% endif %} \
     --compress  \
     --compression-codec snappy \
-    -m 1 \
+    -m {{ table.num_mappers or 1 }} \
 {%- if conf["sqoop_driver"] is defined %}
     {%- if "sqlserver" in conf["sqoop_driver"].lower() -%}
     --query 'SELECT {% for column in table.columns%} {% if loop.last %} {{ '"{}"'.format(column.name) }} {% else %} {{ '"{}",'.format(column.name) }} {% endif %} {% endfor %} FROM {{ table.source.name }} WHERE $CONDITIONS'

--- a/templates/sqoop-parquet-hdfs-hive-merge/sqoop-create.sh
+++ b/templates/sqoop-parquet-hdfs-hive-merge/sqoop-create.sh
@@ -35,7 +35,7 @@ sqoop job -D 'sqoop.metastore.client.record.password=true' \
     --fetch-size 1000 \
     --compress  \
     --compression-codec snappy \
-    -m 1 \
+    -m {{ table.num_mappers or 1 }} \
     --query 'SELECT {{ table.columns|map(attribute='name')|join(',\n\t')}}
         FROM {{ conf.source_database.name }}.{{ table.source.name }} WHERE $CONDITIONS'
 


### PR DESCRIPTION
Added the ability to specify the number of sqoop mappers in a `tables.yml` that then get applied in templates.  If it is not supplied the default of 1 will be used.