### PR TITLE
Added sqoop job name as java option to Sqoop jobs in templates

### DIFF
--- a/templates/shared/sqoop-create.sh
+++ b/templates/shared/sqoop-create.sh
@@ -16,6 +16,7 @@
 set -eu
 sqoop job -D 'sqoop.metastore.client.record.password=true' \
     --create {{ conf.source_database.name }}.{{ table.source.name }}.{{ conf.sqoop_job_name_suffix }} \
+    -D 'mapred.job.name={{ conf.source_database.name }}.{{ table.source.name }}.{{ conf.sqoop_job_name_suffix }}' \
     -- import \
     --connect {{ conf.source_database.connection_string }} \
     --username {{ conf.user_name }} \

--- a/templates/sqoop-parquet-full-load/sqoop-import.sh
+++ b/templates/sqoop-parquet-full-load/sqoop-import.sh
@@ -15,6 +15,7 @@
 # Create a Sqoop job
 set -eu
 sqoop import \
+    -D 'mapred.job.name={{ conf.source_database.name }}.{{ table.source.name }}.{{ conf.sqoop_job_name_suffix }}' \
     --connect '{{ conf.source_database.connection_string }}' \
     --username '{{ conf.user_name }}' \
     --password-file '{{ conf.sqoop_password_file }}' \

--- a/templates/sqoop-parquet-hdfs-hive-merge/sqoop-create.sh
+++ b/templates/sqoop-parquet-hdfs-hive-merge/sqoop-create.sh
@@ -20,6 +20,7 @@
 set -eu
 sqoop job -D 'sqoop.metastore.client.record.password=true' \
     --create {{ conf.source_database.name }}.{{ table.source.name }}.{{ conf.sqoop_job_name_suffix }} \
+    -D 'mapred.job.name={{ conf.source_database.name }}.{{ table.source.name }}.{{ conf.sqoop_job_name_suffix }}' \
     -- import \
     --connect {{ conf.source_database.connection_string }} \
     --username {{ conf.user_name }} \


### PR DESCRIPTION
Added the job name for all Sqoop import scripts. Helps to distinguish between Sqoop jobs for different tables when viewing running jobs in YARN.