### PR TITLE
Fix example links

### DIFF
--- a/examples/sqoop-parquet-hdfs-impala/README.md
+++ b/examples/sqoop-parquet-hdfs-impala/README.md
@@ -1,1 +1,1 @@
-See [integration-tests/sqoop-parquet-hdfs-impala](integration-tests/sqoop-parquet-hdfs-impala]) for example
+Examples have moved [here](https://github.com/Cargill/pipewrench/tree/afoerster-patch-1/integration-tests/sqoop-parquet-hdfs-impala)

--- a/examples/sqoop-parquet-hdfs-kudu-impala/README.md
+++ b/examples/sqoop-parquet-hdfs-kudu-impala/README.md
@@ -1,1 +1,1 @@
-See See [integration-tests/sqoop-parquet-hdfs-kudu-impala](integration-tests/sqoop-parquet-hdfs-kudu-impala]) for example
+Examples have moved [here](https://github.com/Cargill/pipewrench/tree/master/integration-tests/sqoop-parquet-hdfs-kudu-impala)


### PR DESCRIPTION
It's not possible to link to a directory using relative Markdown links
so I used github links instead. Closes #68 