### PR TITLE
Feature/sqoop full load cleanup

### DIFF
--- a/pipewrench/merge.py
+++ b/pipewrench/merge.py
@@ -403,8 +403,8 @@ def cleanse_column(column):
 
     # Replace @ and # with letters to avoid collisions between similar column names
     # e.g. column# and column@
-    column = column.replace('@','a')
-    column = column.replace('#','p')
+    column = column.replace('@', 'a')
+    column = column.replace('#', 'p')
     # Replace all /,-,(,), $ blank spaces with _
     p = re.compile(r'(/|-|\(|\)|\s|\$)')
     column = p.sub('_', column)

--- a/pipewrench/merge.py
+++ b/pipewrench/merge.py
@@ -401,8 +401,12 @@ def cleanse_column(column):
     if column.startswith('_'):
         column = column.replace('_', "", 1)
 
-    # Replace all /,-,(,), #, @, $ blank spaces with _
-    p = re.compile(r'(/|-|\(|\)|\s|#|@|\$)')
+    # Replace @ and # with letters to avoid collisions between similar column names
+    # e.g. column# and column@
+    column = column.replace('@','a')
+    column = column.replace('#','p')
+    # Replace all /,-,(,), $ blank spaces with _
+    p = re.compile(r'(/|-|\(|\)|\s|\$)')
     column = p.sub('_', column)
 
     # After replacing values find any multiple _ and replace them with a single underscore

--- a/templates/sqoop-parquet-full-load/alter-location.sql
+++ b/templates/sqoop-parquet-full-load/alter-location.sql
@@ -1,1 +1,1 @@
-ALTER TABLE {{ conf.staging_database.name }}.{{ table.destination.name }} SET LOCATION '{{ conf.raw_database.path }}/{{ table.destination.name }}_partitioned/ingest_partition=${var:val}/';
+ALTER TABLE `{{ conf.staging_database.name }}`.`{{ table.destination.name }}` SET LOCATION '{{ conf.raw_database.path }}/{{ table.destination.name }}_partitioned/ingest_partition=${var:val}/';

--- a/templates/sqoop-parquet-full-load/avro-table-create.sql
+++ b/templates/sqoop-parquet-full-load/avro-table-create.sql
@@ -14,8 +14,8 @@
 
 -- Create a Parquet table in Impala
 set sync_ddl=1;
-USE {{ conf.raw_database.name }};
-CREATE EXTERNAL TABLE IF NOT EXISTS {{ table.destination.name }}_avro (
+USE `{{ conf.raw_database.name }}`;
+CREATE EXTERNAL TABLE IF NOT EXISTS `{{ table.destination.name }}_avro` (
 {%- for column in table.columns %}
 `{{ cleanse_column(column.name) }}` {{ map_datatypes_v2(column, 'avro') }} COMMENT "{{ column.comment }}"{%- if not loop.last -%}, {% endif %}
 {%- endfor %})

--- a/templates/sqoop-parquet-full-load/avro-table-rowcount.sql
+++ b/templates/sqoop-parquet-full-load/avro-table-rowcount.sql
@@ -13,5 +13,5 @@
     limitations under the License. #}
 
 -- Query Parquet table in Impala
-USE {{ conf.raw_database.name }};
-SELECT COUNT(*) FROM {{ table.destination.name }}_avro;
+USE `{{ conf.raw_database.name }}`;
+SELECT COUNT(*) FROM `{{ table.destination.name }}_avro`;

--- a/templates/sqoop-parquet-full-load/compute-stats-avro.sql
+++ b/templates/sqoop-parquet-full-load/compute-stats-avro.sql
@@ -13,5 +13,5 @@
     limitations under the License.
 -#}
 -- Compute table statistics for optimized joins
-USE {{ conf.raw_database.name }};
-COMPUTE STATS {{ table.destination.name }}_avro;
+USE `{{ conf.raw_database.name }}`;
+COMPUTE STATS `{{ table.destination.name }}_avro`;

--- a/templates/sqoop-parquet-full-load/compute-stats-report.sql
+++ b/templates/sqoop-parquet-full-load/compute-stats-report.sql
@@ -13,5 +13,5 @@
     limitations under the License.
 -#}
 -- Compute table statistics for optimized joins
-USE {{ conf.staging_database.name }};
-COMPUTE STATS {{ table.destination.name }};
+USE `{{ conf.staging_database.name }}`;
+COMPUTE STATS `{{ table.destination.name }}`;

--- a/templates/sqoop-parquet-full-load/insert-overwrite.sql
+++ b/templates/sqoop-parquet-full-load/insert-overwrite.sql
@@ -1,9 +1,9 @@
-INSERT OVERWRITE TABLE {{ conf.raw_database.name }}.{{ table.destination.name }}_partitioned PARTITION (ingest_partition=${var:val})
+INSERT OVERWRITE TABLE `{{ conf.raw_database.name }}`.`{{ table.destination.name }}_partitioned` PARTITION (ingest_partition=${var:val})
 SELECT {% for column in table.columns %}
 {%- if column["datatype"].lower() == "decimal" %}
-cast (`{{ column.name.replace('/','_') }}` as decimal({{column.precision}}, {{column.scale}}) )
-{%- else %} `{{ column.name.replace('/','_') }}`
+cast (`{{ cleanse_column(column.name) }}` as decimal({{column.precision}}, {{column.scale}}) )
+{%- else %} `{{ cleanse_column(column.name) }}`
 {% endif %}
 {%- if not loop.last -%}, {% endif %}
 {%- endfor %}
- FROM {{ conf.raw_database.name }}.{{ table.destination.name }}_avro;
+ FROM `{{ conf.raw_database.name }}`.`{{ table.destination.name }}_avro`;

--- a/templates/sqoop-parquet-full-load/invalidate-metadata.sql
+++ b/templates/sqoop-parquet-full-load/invalidate-metadata.sql
@@ -1,1 +1,1 @@
-INVALIDATE METADATA {{ conf.raw_database.name }}.{{ table.destination.name }}_avro;
+INVALIDATE METADATA `{{ conf.raw_database.name }}`.`{{ table.destination.name }}_avro`;

--- a/templates/sqoop-parquet-full-load/partitioned-table-create.sql
+++ b/templates/sqoop-parquet-full-load/partitioned-table-create.sql
@@ -14,8 +14,8 @@
 
 -- Create a Parquet table in Impala
 set sync_ddl=1;
-USE {{ conf.raw_database.name }};
-CREATE EXTERNAL TABLE IF NOT EXISTS {{ table.destination.name }}_partitioned (
+USE `{{ conf.raw_database.name }}`;
+CREATE EXTERNAL TABLE IF NOT EXISTS `{{ table.destination.name }}_partitioned` (
 {%- for column in table.columns %}
 `{{ cleanse_column(column.name) }}` {{ map_datatypes_v2(column, 'parquet') }} COMMENT "{{ column.comment }}" {%- if not loop.last -%}, {% endif %}
 {%- endfor %})

--- a/templates/sqoop-parquet-full-load/report-table-create.sql
+++ b/templates/sqoop-parquet-full-load/report-table-create.sql
@@ -14,8 +14,8 @@
 
 -- Create a Parquet table in Impala
 set sync_ddl=1;
-USE {{ conf.staging_database.name }};
-CREATE EXTERNAL TABLE IF NOT EXISTS {{ table.destination.name }} (
+USE `{{ conf.staging_database.name }}`;
+CREATE EXTERNAL TABLE IF NOT EXISTS `{{ table.destination.name }}` (
 {%- for column in table.columns %}
 `{{ cleanse_column(column.name) }}` {{ map_datatypes_v2(column, 'parquet') }} COMMENT "{{ column.comment }}" {%- if not loop.last -%}, {% endif %}
 {%- endfor %})

--- a/templates/sqoop-parquet-full-load/report-table-rowcount.sql
+++ b/templates/sqoop-parquet-full-load/report-table-rowcount.sql
@@ -13,5 +13,5 @@
     limitations under the License. #}
 
 -- Query Parquet table in Impala
-USE {{ conf.staging_database.name }};
-SELECT COUNT(*) FROM {{ table.destination.name }};
+USE `{{ conf.staging_database.name }}`;
+SELECT COUNT(*) FROM `{{ table.destination.name }}`;

--- a/templates/sqoop-parquet-full-load/sqoop-import.sh
+++ b/templates/sqoop-parquet-full-load/sqoop-import.sh
@@ -22,7 +22,7 @@ sqoop import \
 {%- if conf["sqoop_driver"] is defined %}
     --driver {{ conf.sqoop_driver }} \
 {%- endif %}
-    {%- set map_java_column = sqoop_map_java_column(table.columns) %}
+    {%- set map_java_column = sqoop_map_java_column(table.columns,clean_column=True) %}
     {%- if map_java_column %}
     {{ map_java_column }} \
     {%- endif %}
@@ -36,7 +36,7 @@ sqoop import \
     -m {{ table.num_mappers or 1 }} \
     --query 'SELECT
 {%- for column in table.columns %}
-"{{ column.name }}" AS {{ cleanse_column }} {%- if not loop.last %}, {%- endif %}
+"{{ column.name }}" AS {{ cleanse_column(column.name) }} {%- if not loop.last %}, {%- endif %}
 {%- endfor %}
 FROM {{ conf.source_database.name }}.{{ table.source.name }}
 WHERE $CONDITIONS'

--- a/templates/sqoop-parquet-full-load/sqoop-import.sh
+++ b/templates/sqoop-parquet-full-load/sqoop-import.sh
@@ -34,14 +34,9 @@ sqoop import \
     --compress  \
     --compression-codec snappy \
     -m {{ table.num_mappers or 1 }} \
-{%- if conf["sqoop_driver"] is defined %}
-    {%- if "sqlserver" in conf["sqoop_driver"].lower() -%}
-    --query 'SELECT {% for column in table.columns%} {% if loop.last %} {{ '"{}"'.format(column.name) }} {% else %} {{ '"{}",'.format(column.name) }} {% endif %} {% endfor %} FROM {{ table.source.name }} WHERE $CONDITIONS'
-    {%- elif "sap" in conf["sqoop_driver"].lower() -%}
-    --query 'SELECT {% for column in table.columns%} {% if loop.last %} {{ '"{}"'.format(column.name) }} {% else %} {{ '"{}",'.format(column.name) }} {% endif %} {% endfor %} FROM {{ conf.source_database.name }}.{{ table.source.name }} WHERE $CONDITIONS'
-    {%- else -%}
-    --query 'SELECT {% for column in table.columns%} {% if loop.last %} {{ column.name }} {% else %} {{ column.name }}, {% endif %} {% endfor %} FROM {{ conf.source_database.name }}.{{ table.source.name }} WHERE $CONDITIONS'
-    {% endif -%}
-{%- else %}
-    --query 'SELECT {% for column in table.columns%} {% if loop.last %} {{ column.name }} {% else %} {{ column.name }}, {% endif %} {% endfor %} FROM {{ conf.source_database.name }}.{{ table.source.name }} WHERE $CONDITIONS'
-{%- endif -%}
+    --query 'SELECT
+{%- for column in table.columns %}
+"{{ column.name }}" AS {{ cleanse_column }} {%- if not loop.last %}, {%- endif %}
+{%- endfor %}
+FROM {{ conf.source_database.name }}.{{ table.source.name }}
+WHERE $CONDITIONS'

--- a/templates/sqoop-parquet-full-load/tables-drop.sql
+++ b/templates/sqoop-parquet-full-load/tables-drop.sql
@@ -1,3 +1,3 @@
-DROP TABLE IF EXISTS {{ conf.raw_database.name }}.{{ table.destination.name }}_avro;
-DROP TABLE IF EXISTS {{ conf.raw_database.name }}.{{ table.destination.name }}_partitioned;
-DROP TABLE IF EXISTS {{ conf.staging_database.name }}.{{ table.destination.name }};
+DROP TABLE IF EXISTS `{{ conf.raw_database.name }}`.`{{ table.destination.name }}_avro`;
+DROP TABLE IF EXISTS `{{ conf.raw_database.name }}`.`{{ table.destination.name }}_partitioned`;
+DROP TABLE IF EXISTS `{{ conf.staging_database.name }}`.`{{ table.destination.name }}`;


### PR DESCRIPTION
These are changes Troy and I were working on, and I ended up using for the Corn Mill Mpls ingest. The biggest change is in cleanse_column() in merge.py, as '@' and '#' characters are replaced with letters (a and p, respectively) instead of underscores. The source had similarly named columns, INL#PG and INL@PG, and we decided this on this change to lower the risk of collisions in cleansed column names.