### PR TITLE
Enhance cleanse_column

### DIFF
--- a/pipewrench/merge.py
+++ b/pipewrench/merge.py
@@ -411,8 +411,8 @@ def cleanse_column(column):
     # e.g. column# and column@
     column = column.replace('@', 'a')
     column = column.replace('#', 'p')
-    # Replace all /,-,(,), $ blank spaces with _
-    p = re.compile(r'(/|-|\(|\)|\s|\$)')
+    # Replace all /,-,(,),$,% blank spaces with _
+    p = re.compile(r'(/|-|\(|\)|\s|\$|%|\.)')
     column = p.sub('_', column)
 
     # After replacing values find any multiple _ and replace them with a single underscore

--- a/pipewrench/merge.py
+++ b/pipewrench/merge.py
@@ -412,7 +412,7 @@ def cleanse_column(column):
     column = column.replace('@', 'a')
     column = column.replace('#', 'p')
     # Replace all /,-,(,),$,% blank spaces with _
-    p = re.compile(r'(/|-|\(|\)|\s|\$|%|\.)')
+    p = re.compile(r'(/|-|\(|\)|\s|\$|%|\.|\|)')
     column = p.sub('_', column)
 
     # After replacing values find any multiple _ and replace them with a single underscore

--- a/pipewrench/merge_test.py
+++ b/pipewrench/merge_test.py
@@ -36,5 +36,55 @@ class CleanseColumnTest(unittest.TestCase):
         actual = merge.cleanse_column(column_name)
         self.assertEqual("gluten_conc_overflow", actual)
 
+    def test_dollar_replace(self):
+        column_name = "gluten_conc$overflow"
+        actual = merge.cleanse_column(column_name)
+        self.assertEqual("gluten_conc_overflow", actual)
+
+    def test_percent_replace(self):
+        column_name = "gluten_conc%overflow"
+        actual = merge.cleanse_column(column_name)
+        self.assertEqual("gluten_conc_overflow", actual)
+
+    def test_underscore_shortening_replace(self):
+        column_name = "gluten_conc__overflow"
+        actual = merge.cleanse_column(column_name)
+        self.assertEqual("gluten_conc_overflow", actual)
+
+    def test_remove_initial_lodash(self):
+        column_name = "_gluten_conc_overflow"
+        actual = merge.cleanse_column(column_name)
+        self.assertEqual("gluten_conc_overflow", actual)
+
+    def test_remove_initial_slash(self):
+        column_name = "/gluten_conc_overflow"
+        actual = merge.cleanse_column(column_name)
+        self.assertEqual("gluten_conc_overflow", actual)
+
+    def test_at_replace(self):
+        column_name = "gluten_conc@overflow"
+        actual = merge.cleanse_column(column_name)
+        self.assertEqual("gluten_concaoverflow", actual)
+
+    def test_pound_replace(self):
+        column_name = "gluten_conc#overflow"
+        actual = merge.cleanse_column(column_name)
+        self.assertEqual("gluten_concpoverflow", actual)
+
+    def test_paren_replace(self):
+        column_name = "slope (rise/run)"
+        actual = merge.cleanse_column(column_name)
+        self.assertEqual("slope_rise_run_", actual)
+
+    def test_space_replace(self):
+        column_name = "hot dish"
+        actual = merge.cleanse_column(column_name)
+        self.assertEqual("hot_dish", actual)
+
+    def test_dash_replace(self):
+        column_name = "hot-dish"
+        actual = merge.cleanse_column(column_name)
+        self.assertEqual("hot_dish", actual)
+
 if __name__ == '__main__':
     unittest.main()

--- a/pipewrench/merge_test.py
+++ b/pipewrench/merge_test.py
@@ -86,5 +86,10 @@ class CleanseColumnTest(unittest.TestCase):
         actual = merge.cleanse_column(column_name)
         self.assertEqual("hot_dish", actual)
 
+    def test_pipe_replace(self):
+        column_name = "hot|dish"
+        actual = merge.cleanse_column(column_name)
+        self.assertEqual("hot_dish", actual)
+
 if __name__ == '__main__':
     unittest.main()

--- a/pipewrench/merge_test.py
+++ b/pipewrench/merge_test.py
@@ -21,7 +21,7 @@ class MergeTest(unittest.TestCase):
     def test_throw_error_on_undefined(self):
         values = {'conf': 'value'}
 
-        self.assertEquals('value', merge.render("{{ conf }}", **values))
+        self.assertEqual('value', merge.render("{{ conf }}", **values))
 
     def test_render_with_type_mapping(self):
         global type_mappings
@@ -29,3 +29,12 @@ class MergeTest(unittest.TestCase):
         values = {'conf': 'nevermind', 'column': {'datatype': 'blob'}}
 
         assert 'string' == merge.render("{{ map_datatypes(column).kudu }}", **values)
+
+class CleanseColumnTest(unittest.TestCase):
+    def test_period_replace(self):
+        column_name = "gluten_conc.overflow"
+        actual = merge.cleanse_column(column_name)
+        self.assertEqual("gluten_conc_overflow", actual)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import unittest
 import os
 import sys
 
-version = '1.0.2'
+version = '1.0.3'
 
 def pipewrench_test_suite():
     test_loader = unittest.TestLoader()


### PR DESCRIPTION
I updated cleanse_column to replace period characters (`.`) with underscores (`_`), similar to the behavior for other special characters that are occasionally found in SQL column names.

I also created 13 unit tests to give developers greater confidence that the method is behaving as expected.